### PR TITLE
Fixed color changing issue

### DIFF
--- a/lib/PSStroke.ts
+++ b/lib/PSStroke.ts
@@ -168,7 +168,6 @@ const PSStrokeImpl = <any>fabricjs.util.createClass(
         p1 = this.strokePoints[i];
         p2 = this.strokePoints[i + 1];
       
-        ctx.closePath();
         ctx.stroke();
       }
 

--- a/lib/PSStroke.ts
+++ b/lib/PSStroke.ts
@@ -146,6 +146,8 @@ const PSStrokeImpl = <any>fabricjs.util.createClass(
       }
       
       ctx.strokeStyle = this.stroke;
+			ctx.lineCap = this.strokeLineCap;
+			ctx.lineJoin = this.strokeLineJoin;
 
       for (i = 1, len = this.strokePoints.length; i < len; i++) {
         ctx.beginPath();
@@ -163,9 +165,11 @@ const PSStrokeImpl = <any>fabricjs.util.createClass(
           mid.x - multSignX * strokeWidth + l,
           mid.y - multSignY * strokeWidth + t
         );
-        ctx.stroke();
         p1 = this.strokePoints[i];
         p2 = this.strokePoints[i + 1];
+      
+        ctx.closePath();
+        ctx.stroke();
       }
 
       // ctx.restore();

--- a/lib/PSStroke.ts
+++ b/lib/PSStroke.ts
@@ -144,6 +144,8 @@ const PSStrokeImpl = <any>fabricjs.util.createClass(
         p2.x += strokeWidth;
         mid.x = p1.x;
       }
+      
+      ctx.strokeStyle = this.stroke;
 
       for (i = 1, len = this.strokePoints.length; i < len; i++) {
         ctx.beginPath();


### PR DESCRIPTION
As explained in #12 , the color of the PSStroke changes to black as soon as the user releases the mouse button. This fixes that